### PR TITLE
Denying all permissions not opted into.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -68,6 +68,12 @@ export function view() {
                         return;
                     }
                     
+                    var session = remote.session.fromPartition(el.partition);
+                    
+                    session.setPermissionRequestHandler((contents, permission, cb) => {
+                        cb((tab.permissions && tab.permissions.includes(permission)) === true);
+                    });
+                    
                     // Listen for attempts to open a new window and open them
                     // in the system default browser
                     el.addEventListener('new-window', (e) => {


### PR DESCRIPTION
Should probably add this to the setup page that no longer exists too, but the idea is:

``` json
{
    "tabs" : [
        {
            "type" : "discord",
            "url" : "https://discordapp.com/channels/@me",
            "permissions" : ["media"]
        }
    ]
}
```

Permissions are (according to electron/electron#4223): `media`, `geolocation`, `notifications`, `midiSysex`, `pointerLock`, and `fullscreen`.
